### PR TITLE
fix: BatchSubmit decorator enforces unique key

### DIFF
--- a/src/chaincode/LaunchpadContract.ts
+++ b/src/chaincode/LaunchpadContract.ts
@@ -226,6 +226,7 @@ export class LaunchpadContract extends GalaContract {
     in: BatchDto,
     out: "object",
     description: "Submit a batch of transactions",
+    enforceUniqueKey: true,
     verifySignature: true
   })
   public async BatchSubmit(ctx: GalaChainContext, batchDto: BatchDto): Promise<GalaChainResponse<unknown>[]> {


### PR DESCRIPTION
Recent changes cause chaincode to fail to start:

NotImplementedError: SUBMIT transaction 'BatchSubmit' must have enforceUniqueKey defined
    at /assets-chaincode/node_modules/@gala-chain/chaincode/lib/src/contracts/GalaTransaction.js:76:19
    at DecorateProperty (/assets-chaincode/node_modules/class-validator-jsonschema/node_modules/reflect-metadata/Reflect.js:561:33)
    at Reflect.decorate (/assets-chaincode/node_modules/class-validator-jsonschema/node_modules/reflect-metadata/Reflect.js:136:24)
    at Object.__decorate (/assets-chaincode/node_modules/tslib/tslib.js:106:96)
    at Object.<anonymous> (/assets-chaincode/node_modules/@gala-chain/launchpad/lib/src/chaincode/LaunchpadContract.js:269:9)
    at Module._compile (node:internal/modules/cjs/loader:1364:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1422:10)
    at Module.load (node:internal/modules/cjs/loader:1203:32)
    at Module._load (node:internal/modules/cjs/loader:1019:12)
    at Module.require (node:internal/modules/cjs/loader:1231:19) {
  key: 'NOT_IMPLEMENTED',
  payload: undefined,
  code: 501
}